### PR TITLE
fix: adjust footer to sit at bottom page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,6 +32,11 @@ time, mark, audio, video {
 	--accent: rgb(78, 131, 131);
 }
 
+.App {
+    position: relative;
+    min-height: 100vh;
+}
+
 .blueBtn {
     background-color: var(--accent);
     border: none;
@@ -51,7 +56,7 @@ time, mark, audio, video {
 }
 
 .contentBody {
-    padding: 0 8rem 2rem 8rem;
+    padding: 0 8rem 15rem 8rem;
 }
 
 input {

--- a/src/components/Footer.module.css
+++ b/src/components/Footer.module.css
@@ -1,20 +1,23 @@
 footer {
-    display: flex;
-    justify-content: space-between;
     align-items: center;
     background-color: rgb(74, 72, 71);
     color: var(--text-light);
-    width: 100%;
-    height: 150px;
-    padding: 0 2.8rem;
+    display: flex;
     font-size: 1.5rem;
+    height: 10rem;
+    justify-content: space-between;
+    margin-top: auto;
+    padding: 0 2.8rem;
+    position: absolute;
+    bottom: 0;
+    width: 100%;
 }
 
 .socialLinks {
     display: flex;
     gap: 0.5rem;
-    margin-top: 0.8rem;
     justify-content: center;
+    margin-top: 0.8rem;
 }
 
 .socialLinks div {


### PR DESCRIPTION
This PR fixes an issue with the footer not staying in place at the bottom of the page when there is little to no content on the page.

<img width="863" alt="CleanShot 2023-01-29 at 16 11 39@2x" src="https://user-images.githubusercontent.com/49492414/215359948-f16f27c4-9015-4c8e-9c49-1a32de648550.png">

The [approach](https://www.freecodecamp.org/news/how-to-keep-your-footer-where-it-belongs-59c6aa05c59c/) to resolve this is to set the height of the main container for the page to be 100vh. The footer is given a specific height, set to have a position of absolute and bottom position of 0. The main contentBody container is then set to have a bottom padding that is a few pixels more than the height of the footer. This will ensure that the page content will not overlap the footer.
